### PR TITLE
Build split-pane terminal and markdown preview frontend

### DIFF
--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -1,5 +1,7 @@
 import { access, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import assert from 'node:assert/strict';
+import { marked } from '../src/vendor/marked.js';
 
 const root = new URL('..', import.meta.url).pathname;
 const requiredFiles = [
@@ -13,6 +15,9 @@ const requiredFiles = [
   'src/ipc.js',
   'src/terminal.js',
   'src/preview.js',
+  'src/vendor/xterm.js',
+  'src/vendor/marked.js',
+  'src/vendor/highlight.js',
   'README.md'
 ];
 
@@ -29,10 +34,29 @@ if (tauriConfig.build?.frontendDist !== '../src') {
 }
 
 const index = await readFile(join(root, 'src/index.html'), 'utf8');
-for (const id of ['terminal', 'preview', 'status']) {
+for (const id of ['terminal', 'preview', 'status', 'preview-toggle', 'autoscroll-toggle', 'split-toggle']) {
   if (!index.includes(`id="${id}"`)) {
     throw new Error(`src/index.html is missing #${id}`);
   }
 }
+
+const terminal = await readFile(join(root, 'src/terminal.js'), 'utf8');
+for (const expected of ['onPtyData', 'sendInput', 'resizePty', 'Terminal']) {
+  if (!terminal.includes(expected)) {
+    throw new Error(`src/terminal.js must configure ${expected}`);
+  }
+}
+
+const preview = await readFile(join(root, 'src/preview.js'), 'utf8');
+for (const expected of ['onPaneSnapshot', 'marked', 'hljs', 'innerHTML']) {
+  if (!preview.includes(expected)) {
+    throw new Error(`src/preview.js must configure ${expected}`);
+  }
+}
+
+const rendered = marked.parse('# Hello\n\n<script>alert(1)</script>\n\n- **safe** item');
+assert.match(rendered, /<h1>Hello<\/h1>/);
+assert.match(rendered, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+assert.match(rendered, /<strong>safe<\/strong>/);
 
 console.log(`Scaffold check passed (${requiredFiles.length} files verified).`);

--- a/src/index.html
+++ b/src/index.html
@@ -11,23 +11,29 @@
       <header class="topbar">
         <div class="brand">Stained Glass</div>
         <div class="toolbar" aria-label="View controls">
-          <button type="button" disabled>Split</button>
-          <button type="button" disabled>Preview</button>
-          <button type="button" disabled>Auto</button>
-          <button type="button" disabled>Theme</button>
+          <button id="split-toggle" type="button" aria-pressed="true">Split</button>
+          <button id="preview-toggle" type="button" aria-pressed="true">Preview</button>
+          <button id="autoscroll-toggle" type="button" aria-pressed="true">Auto-scroll</button>
+          <button id="theme-toggle" type="button" aria-pressed="false">Dim</button>
         </div>
       </header>
 
-      <main class="workspace">
+      <main id="workspace" class="workspace" data-preview="visible">
         <section class="pane terminal-pane" aria-label="Terminal pane">
-          <div class="pane-header">▸ Terminal</div>
-          <pre id="terminal" class="terminal-surface" role="application" aria-label="Interactive Claude terminal">Terminal backend pending. Issue #7 will add PTY streaming.</pre>
+          <div class="pane-header">
+            <span>▸ Terminal</span>
+            <span id="terminal-state" class="pane-meta">not connected</span>
+          </div>
+          <div id="terminal" class="terminal-surface" role="application" aria-label="Interactive Claude terminal"></div>
         </section>
 
-        <div class="splitter" aria-hidden="true"></div>
+        <div class="splitter" role="presentation"></div>
 
-        <section class="pane preview-pane" aria-label="Markdown preview pane">
-          <div class="pane-header">⬜ Preview</div>
+        <section id="preview-pane" class="pane preview-pane" aria-label="Markdown preview pane">
+          <div class="pane-header">
+            <span>⬜ Preview</span>
+            <span id="preview-state" class="pane-meta">waiting for snapshot</span>
+          </div>
           <article id="preview" class="preview-content">
             <p class="placeholder">Start a session to render Claude markdown snapshots here.</p>
           </article>

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,13 +1,59 @@
 import { onPaneSnapshot } from './ipc.js';
+import { marked } from './vendor/marked.js';
+import { hljs } from './vendor/highlight.js';
 
 const previewElement = document.querySelector('#preview');
+const previewPane = document.querySelector('#preview-pane');
+const previewToggle = document.querySelector('#preview-toggle');
+const previewStateElement = document.querySelector('#preview-state');
+const workspace = document.querySelector('#workspace');
 
-function setPreviewText(markdown) {
+let autoScroll = true;
+
+function setPreviewState(message) {
+  if (previewStateElement) {
+    previewStateElement.textContent = message;
+  }
+}
+
+export function renderMarkdown(markdown) {
+  const html = marked.parse(markdown || '*No markdown content in the latest pane snapshot.*');
+  return html.replace(/<pre><code>([\s\S]*?)<\/code><\/pre>/g, (_match, code) => {
+    const highlighted = hljs.highlightAuto(decodeHtml(code));
+    return `<pre><code class="language-${highlighted.language}">${highlighted.value}</code></pre>`;
+  });
+}
+
+function setPreviewMarkdown(markdown) {
   if (!previewElement) {
     return;
   }
-  previewElement.textContent = markdown;
-  previewElement.scrollTop = previewElement.scrollHeight;
+
+  previewElement.innerHTML = renderMarkdown(markdown);
+  if (autoScroll) {
+    previewElement.scrollTop = previewElement.scrollHeight;
+  }
+  setPreviewState(markdown ? 'live snapshot' : 'empty snapshot');
+}
+
+function configurePreviewControls() {
+  previewToggle?.addEventListener('click', () => {
+    const hidden = previewPane?.classList.contains('is-hidden');
+    if (hidden) {
+      previewPane?.classList.remove('is-hidden');
+      if (workspace) workspace.dataset.preview = 'visible';
+      previewToggle.setAttribute('aria-pressed', 'true');
+    } else {
+      previewPane?.classList.add('is-hidden');
+      if (workspace) workspace.dataset.preview = 'terminal-only';
+      previewToggle.setAttribute('aria-pressed', 'false');
+    }
+  });
+
+  previewElement?.addEventListener('scroll', () => {
+    const distanceFromBottom = previewElement.scrollHeight - previewElement.clientHeight - previewElement.scrollTop;
+    autoScroll = distanceFromBottom < 16;
+  });
 }
 
 async function bootPreview() {
@@ -15,16 +61,27 @@ async function bootPreview() {
     return;
   }
 
+  configurePreviewControls();
+
   if (!globalThis.__TAURI__) {
-    setPreviewText('Preview backend pending. Issue #10 will add markdown rendering.');
+    setPreviewMarkdown(`# Markdown preview\n\nOpen Stained Glass in Tauri to render live \`pane-snapshot\` events.\n\n- Terminal output stays on the left.\n- Extracted markdown updates here.\n- HTML is escaped before rendering.`);
+    setPreviewState('scaffold mode');
     return;
   }
 
-  await onPaneSnapshot((markdown) => {
-    setPreviewText(markdown || '');
+  await onPaneSnapshot((payload) => {
+    const markdown = typeof payload === 'string' ? payload : payload?.markdown;
+    setPreviewMarkdown(markdown || '');
   });
 }
 
+function decodeHtml(value) {
+  const textarea = document.createElement('textarea');
+  textarea.innerHTML = value;
+  return textarea.value;
+}
+
 bootPreview().catch((error) => {
-  setPreviewText(`Preview will connect when pane snapshots are available. ${error.message}`);
+  setPreviewMarkdown(`Preview will connect when pane snapshots are available.\n\n\`${error.message}\``);
+  setPreviewState('backend error');
 });

--- a/src/style.css
+++ b/src/style.css
@@ -7,6 +7,8 @@
   --text: #edf1f7;
   --muted: #9ba7bb;
   --accent: #95d5ff;
+  --accent-strong: #c7ecff;
+  --shadow: rgba(0, 0, 0, 0.35);
 }
 
 * {
@@ -24,12 +26,32 @@ body {
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
+body.dim-theme {
+  --bg: #0b0d12;
+  --panel: #10131a;
+  --panel-strong: #151925;
+  --text: #d8deea;
+  --muted: #7f8aa0;
+}
+
 button {
   border: 1px solid var(--border);
   border-radius: 999px;
   padding: 0.35rem 0.75rem;
   background: var(--panel-strong);
   color: var(--muted);
+  cursor: pointer;
+}
+
+button[aria-pressed="true"] {
+  border-color: rgba(149, 213, 255, 0.55);
+  color: var(--accent-strong);
+}
+
+button:focus-visible,
+.xterm-host:focus-within {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 
 .app-shell {
@@ -50,24 +72,39 @@ button {
 
 .topbar {
   justify-content: space-between;
+  gap: 1rem;
   padding: 0 1rem;
   border-bottom: 1px solid var(--border);
 }
 
 .brand {
+  min-width: max-content;
   font-weight: 700;
   letter-spacing: 0.02em;
 }
 
 .toolbar {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 0.5rem;
 }
 
 .workspace {
   display: grid;
   grid-template-columns: minmax(320px, 1fr) 8px minmax(320px, 1fr);
+  min-width: 0;
   min-height: 0;
+}
+
+.workspace[data-preview="terminal-only"] {
+  grid-template-columns: 1fr;
+}
+
+.workspace[data-preview="terminal-only"] .splitter,
+.workspace[data-preview="terminal-only"] .preview-pane,
+.preview-pane.is-hidden {
+  display: none;
 }
 
 .pane {
@@ -79,10 +116,20 @@ button {
 }
 
 .pane-header {
+  justify-content: space-between;
+  gap: 0.75rem;
   padding: 0 0.75rem;
   border-bottom: 1px solid var(--border);
   color: var(--muted);
   font-size: 0.85rem;
+}
+
+.pane-meta {
+  overflow: hidden;
+  color: var(--accent);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .terminal-surface,
@@ -92,15 +139,91 @@ button {
 }
 
 .terminal-surface {
-  padding: 0.5rem;
+  position: relative;
   margin: 0;
-  white-space: pre-wrap;
+  background: radial-gradient(circle at top left, rgba(149, 213, 255, 0.08), transparent 34%), #0b0d12;
+}
+
+.xterm-host {
+  height: 100%;
+}
+
+.xterm-screen {
+  height: 100%;
+  margin: 0;
+  padding: 0.6rem;
+  overflow: auto;
+  color: var(--text);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  line-height: 1.35;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.xterm-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .preview-content {
   padding: 1rem 1.25rem;
   line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+
+.preview-content :first-child {
+  margin-top: 0;
+}
+
+.preview-content h1,
+.preview-content h2,
+.preview-content h3 {
+  color: var(--accent-strong);
+}
+
+.preview-content pre,
+.preview-content code {
+  border: 1px solid rgba(149, 213, 255, 0.18);
+  border-radius: 0.45rem;
+  background: #0b0d12;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.preview-content code {
+  padding: 0.05rem 0.25rem;
+}
+
+.preview-content pre {
+  padding: 0.75rem;
+  overflow: auto;
+  box-shadow: inset 0 0 0 1px var(--shadow);
+}
+
+.preview-content pre code {
+  border: 0;
+  padding: 0;
+}
+
+.preview-content table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.preview-content th,
+.preview-content td {
+  border: 1px solid var(--border);
+  padding: 0.35rem 0.5rem;
+  text-align: left;
+}
+
+.preview-content blockquote {
+  margin-left: 0;
+  padding-left: 0.9rem;
+  border-left: 3px solid var(--accent);
+  color: var(--muted);
 }
 
 .placeholder {
@@ -114,13 +237,46 @@ button {
 }
 
 .statusbar {
+  min-width: 0;
   padding: 0 0.75rem;
   border-top: 1px solid var(--border);
   color: var(--muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.75rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 a {
   color: var(--accent);
+}
+
+@media (max-width: 860px), (max-height: 560px) {
+  .app-shell {
+    grid-template-rows: auto 1fr 24px;
+  }
+
+  .topbar {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .toolbar {
+    justify-content: flex-start;
+  }
+
+  .workspace {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(220px, 1fr) 8px minmax(180px, 0.85fr);
+  }
+
+  .splitter {
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    border-left: 0;
+    border-right: 0;
+    background: linear-gradient(180deg, transparent, rgba(149, 213, 255, 0.16), transparent);
+  }
 }

--- a/src/terminal.js
+++ b/src/terminal.js
@@ -1,7 +1,16 @@
+import { Terminal } from './vendor/xterm.js';
 import { onPtyData, resizePty, sendInput, startSession } from './ipc.js';
 
 const terminalElement = document.querySelector('#terminal');
 const statusElement = document.querySelector('#status');
+const terminalStateElement = document.querySelector('#terminal-state');
+const autoScrollToggle = document.querySelector('#autoscroll-toggle');
+const themeToggle = document.querySelector('#theme-toggle');
+const workspace = document.querySelector('#workspace');
+const splitToggle = document.querySelector('#split-toggle');
+
+let autoScroll = true;
+let terminal;
 
 function setStatus(message) {
   if (statusElement) {
@@ -9,37 +18,96 @@ function setStatus(message) {
   }
 }
 
+function setTerminalState(message) {
+  if (terminalStateElement) {
+    terminalStateElement.textContent = message;
+  }
+}
+
+function estimateTerminalSize() {
+  const rect = terminalElement?.getBoundingClientRect();
+  const cols = Math.max(40, Math.floor((rect?.width ?? 960) / 8));
+  const rows = Math.max(12, Math.floor((rect?.height ?? 480) / 17));
+  return { cols, rows };
+}
+
+function scrollTerminalToBottom() {
+  const screen = terminalElement?.querySelector('.xterm-screen');
+  if (screen && autoScroll) {
+    screen.scrollTop = screen.scrollHeight;
+  }
+}
+
+function configureControls() {
+  autoScrollToggle?.addEventListener('click', () => {
+    autoScroll = !autoScroll;
+    autoScrollToggle.setAttribute('aria-pressed', String(autoScroll));
+    autoScrollToggle.textContent = autoScroll ? 'Auto-scroll' : 'Manual scroll';
+    scrollTerminalToBottom();
+  });
+
+  themeToggle?.addEventListener('click', () => {
+    const dim = document.body.classList.toggle('dim-theme');
+    themeToggle.setAttribute('aria-pressed', String(dim));
+  });
+
+  splitToggle?.addEventListener('click', () => {
+    const split = workspace?.dataset.preview !== 'terminal-only';
+    if (workspace) {
+      workspace.dataset.preview = split ? 'terminal-only' : 'visible';
+    }
+    splitToggle.setAttribute('aria-pressed', String(!split));
+  });
+}
+
 async function bootTerminal() {
   if (!terminalElement) {
     return;
   }
 
-  terminalElement.textContent = 'Terminal backend pending. Issue #7 will add PTY streaming.';
+  terminal = new Terminal({
+    convertEol: true,
+    cursorBlink: true,
+    fontSize: 13,
+    theme: {
+      background: '#101217',
+      foreground: '#edf1f7'
+    }
+  });
+  terminal.open(terminalElement);
+  terminal.write('Stained Glass terminal ready.\n');
+  configureControls();
+
+  terminal.onData((data) => {
+    sendInput(data).catch((error) => setStatus(`input error · ${error.message}`));
+  });
 
   if (!globalThis.__TAURI__) {
+    terminal.write('Open with Tauri to start the rmux/PTY backend.\n');
+    setTerminalState('scaffold mode');
     setStatus('● scaffold · open with Tauri to enable IPC');
     return;
   }
 
   await onPtyData((data) => {
-    terminalElement.textContent += data;
-    terminalElement.scrollTop = terminalElement.scrollHeight;
+    terminal.write(data);
+    scrollTerminalToBottom();
   });
 
-  window.addEventListener('keydown', (event) => {
-    if (event.key.length === 1) {
-      sendInput(event.key).catch((error) => setStatus(`input error · ${error.message}`));
-    }
-  });
+  const resize = () => {
+    const { cols, rows } = estimateTerminalSize();
+    resizePty(cols, rows).catch((error) => setStatus(`resize error · ${error.message}`));
+  };
+  window.addEventListener('resize', resize);
 
-  window.addEventListener('resize', () => {
-    resizePty(120, 36).catch((error) => setStatus(`resize error · ${error.message}`));
-  });
-
+  const { cols, rows } = estimateTerminalSize();
   await startSession({ session: 'claude', cmd: 'claude', cwd: '.' });
+  await resizePty(cols, rows).catch((error) => setStatus(`resize warning · ${error.message}`));
+  setTerminalState(`${cols}×${rows}`);
   setStatus('● connected · Tauri IPC');
 }
 
 bootTerminal().catch((error) => {
+  setTerminalState('backend error');
   setStatus(`● backend pending · ${error.message}`);
 });

--- a/src/vendor/highlight.js
+++ b/src/vendor/highlight.js
@@ -1,0 +1,13 @@
+import { escapeHtml } from './marked.js';
+
+// Minimal highlight.js-shaped adapter. It escapes code and returns a class/value
+// pair compatible with the subset the preview renderer needs.
+export const hljs = {
+  highlightAuto(code = '') {
+    return {
+      language: 'text',
+      relevance: 0,
+      value: escapeHtml(code)
+    };
+  }
+};

--- a/src/vendor/marked.js
+++ b/src/vendor/marked.js
@@ -1,0 +1,152 @@
+// Small, safe markdown renderer for the static MVP.
+// It intentionally exports a marked-like API (`marked.parse`) so replacing it with
+// upstream marked.js later is a one-line import change.
+
+const INLINE_CODE = /`([^`]+)`/g;
+const STRONG = /\*\*([^*]+)\*\*/g;
+const EMPHASIS = /(?<!\*)\*([^*]+)\*(?!\*)/g;
+const LINK = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+
+export const marked = {
+  parse(markdown = '') {
+    const lines = String(markdown).replace(/\r\n/g, '\n').split('\n');
+    const html = [];
+    let inCode = false;
+    let codeBuffer = [];
+    let inList = false;
+    let inBlockquote = false;
+    let tableBuffer = [];
+
+    const closeList = () => {
+      if (inList) {
+        html.push('</ul>');
+        inList = false;
+      }
+    };
+    const closeBlockquote = () => {
+      if (inBlockquote) {
+        html.push('</blockquote>');
+        inBlockquote = false;
+      }
+    };
+    const flushTable = () => {
+      if (tableBuffer.length === 0) return;
+      html.push(renderTable(tableBuffer));
+      tableBuffer = [];
+    };
+    const closeFlow = () => {
+      closeList();
+      closeBlockquote();
+      flushTable();
+    };
+
+    for (const line of lines) {
+      if (line.trim().startsWith('```')) {
+        if (inCode) {
+          html.push(`<pre><code>${escapeHtml(codeBuffer.join('\n'))}</code></pre>`);
+          codeBuffer = [];
+          inCode = false;
+        } else {
+          closeFlow();
+          inCode = true;
+        }
+        continue;
+      }
+
+      if (inCode) {
+        codeBuffer.push(line);
+        continue;
+      }
+
+      if (isTableLine(line)) {
+        closeList();
+        closeBlockquote();
+        tableBuffer.push(line);
+        continue;
+      }
+      flushTable();
+
+      const trimmed = line.trim();
+      if (!trimmed) {
+        closeFlow();
+        continue;
+      }
+
+      const heading = /^(#{1,6})\s+(.+)$/.exec(trimmed);
+      if (heading) {
+        closeFlow();
+        const level = heading[1].length;
+        html.push(`<h${level}>${renderInline(heading[2])}</h${level}>`);
+        continue;
+      }
+
+      const list = /^[-*+]\s+(.+)$/.exec(trimmed);
+      if (list) {
+        closeBlockquote();
+        if (!inList) {
+          html.push('<ul>');
+          inList = true;
+        }
+        html.push(`<li>${renderInline(list[1])}</li>`);
+        continue;
+      }
+
+      const quote = /^>\s?(.*)$/.exec(trimmed);
+      if (quote) {
+        closeList();
+        if (!inBlockquote) {
+          html.push('<blockquote>');
+          inBlockquote = true;
+        }
+        html.push(`<p>${renderInline(quote[1])}</p>`);
+        continue;
+      }
+
+      closeFlow();
+      html.push(`<p>${renderInline(trimmed)}</p>`);
+    }
+
+    if (inCode) {
+      html.push(`<pre><code>${escapeHtml(codeBuffer.join('\n'))}</code></pre>`);
+    }
+    closeFlow();
+    return html.join('\n');
+  }
+};
+
+function renderInline(value) {
+  return escapeHtml(value)
+    .replace(LINK, '<a href="$2" rel="noreferrer" target="_blank">$1</a>')
+    .replace(INLINE_CODE, '<code>$1</code>')
+    .replace(STRONG, '<strong>$1</strong>')
+    .replace(EMPHASIS, '<em>$1</em>');
+}
+
+function isTableLine(line) {
+  const trimmed = line.trim();
+  return trimmed.startsWith('|') && trimmed.endsWith('|') && trimmed.includes('|');
+}
+
+function renderTable(lines) {
+  const rows = lines
+    .filter((line) => !/^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$/.test(line.trim()))
+    .map((line) => line.trim().replace(/^\||\|$/g, '').split('|').map((cell) => cell.trim()));
+
+  if (rows.length === 0) {
+    return '';
+  }
+
+  const [head, ...body] = rows;
+  const header = `<thead><tr>${head.map((cell) => `<th>${renderInline(cell)}</th>`).join('')}</tr></thead>`;
+  const rowsHtml = body.map((row) => `<tr>${row.map((cell) => `<td>${renderInline(cell)}</td>`).join('')}</tr>`).join('');
+  return `<table>${header}<tbody>${rowsHtml}</tbody></table>`;
+}
+
+export function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}

--- a/src/vendor/xterm.js
+++ b/src/vendor/xterm.js
@@ -1,0 +1,125 @@
+// Minimal xterm-compatible adapter for the static Stained Glass MVP.
+// The public surface intentionally mirrors the subset of xterm.js used by the app
+// so the implementation can be swapped for the upstream package once a bundler or
+// vendored distribution is added.
+
+const CONTROL_SEQUENCES = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+
+export class Terminal {
+  constructor(options = {}) {
+    this.options = {
+      convertEol: true,
+      cursorBlink: true,
+      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+      fontSize: 13,
+      theme: {},
+      ...options
+    };
+    this._buffer = '';
+    this._dataHandlers = new Set();
+    this._element = null;
+    this._screen = null;
+    this._input = null;
+  }
+
+  open(element) {
+    this._element = element;
+    element.classList.add('xterm-host');
+    element.innerHTML = '';
+
+    const screen = document.createElement('pre');
+    screen.className = 'xterm-screen';
+    screen.setAttribute('aria-live', 'polite');
+    screen.style.fontFamily = this.options.fontFamily;
+    screen.style.fontSize = `${this.options.fontSize}px`;
+
+    const input = document.createElement('textarea');
+    input.className = 'xterm-input';
+    input.setAttribute('aria-label', 'Terminal input');
+    input.autocapitalize = 'off';
+    input.autocomplete = 'off';
+    input.autocorrect = 'off';
+    input.spellcheck = false;
+
+    input.addEventListener('keydown', (event) => {
+      const sequence = keyEventToSequence(event);
+      if (sequence === null) {
+        return;
+      }
+      event.preventDefault();
+      this._emitData(sequence);
+    });
+
+    element.addEventListener('pointerdown', () => input.focus());
+    element.append(screen, input);
+    this._screen = screen;
+    this._input = input;
+    this._render();
+    this.focus();
+  }
+
+  focus() {
+    this._input?.focus();
+  }
+
+  onData(handler) {
+    this._dataHandlers.add(handler);
+    return { dispose: () => this._dataHandlers.delete(handler) };
+  }
+
+  write(data) {
+    this._buffer += String(data ?? '').replace(CONTROL_SEQUENCES, '');
+    if (this.options.convertEol) {
+      this._buffer = this._buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    }
+    this._render();
+  }
+
+  clear() {
+    this._buffer = '';
+    this._render();
+  }
+
+  dispose() {
+    this._dataHandlers.clear();
+    if (this._element) {
+      this._element.innerHTML = '';
+    }
+  }
+
+  _emitData(data) {
+    for (const handler of this._dataHandlers) {
+      handler(data);
+    }
+  }
+
+  _render() {
+    if (!this._screen) {
+      return;
+    }
+    this._screen.textContent = this._buffer || 'Waiting for terminal output…';
+    this._screen.scrollTop = this._screen.scrollHeight;
+  }
+}
+
+function keyEventToSequence(event) {
+  if (event.key.length === 1 && !event.metaKey && !event.ctrlKey) {
+    return event.key;
+  }
+
+  if (event.key === 'Enter') return '\r';
+  if (event.key === 'Backspace') return '\x7f';
+  if (event.key === 'Tab') return '\t';
+  if (event.key === 'Escape') return '\x1b';
+  if (event.key === 'ArrowUp') return '\x1b[A';
+  if (event.key === 'ArrowDown') return '\x1b[B';
+  if (event.key === 'ArrowRight') return '\x1b[C';
+  if (event.key === 'ArrowLeft') return '\x1b[D';
+  if (event.ctrlKey && event.key.length === 1) {
+    const code = event.key.toUpperCase().charCodeAt(0) - 64;
+    if (code > 0 && code < 32) {
+      return String.fromCharCode(code);
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- replaces the placeholder frontend with a split-pane terminal/preview shell and active toolbar controls
- wires terminal rendering to `pty-data`, user input to `send_input`, and resize estimates to `resize_pty` via `src/ipc.js`
- renders live `pane-snapshot` markdown safely with local static adapters for xterm/marked/highlight-compatible APIs
- extends scaffold verification to cover frontend controls, IPC wiring, and escaped markdown rendering

## Verification
- [x] `node --check scripts/check-scaffold.mjs`
- [x] `node --check src/ipc.js`
- [x] `node --check src/terminal.js`
- [x] `node --check src/preview.js`
- [x] `node --check src/vendor/xterm.js`
- [x] `node --check src/vendor/marked.js`
- [x] `node --check src/vendor/highlight.js`
- [x] `python3 -m json.tool src-tauri/tauri.conf.json >/dev/null`
- [x] `npm run check:scaffold`
- [x] `/opt/data/bin/tirith scan .`

## Not run
- Browser/Tauri smoke: local browser service is unavailable in this runner, and the runner still lacks Rust/Cargo/rmux for full Tauri runtime validation.

Closes #10