### PR TITLE
Implement stain CLI for session control and snapshots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["src-tauri"]
+members = ["src-tauri", "stain"]
 resolver = "2"
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -1,32 +1,39 @@
 # Stained Glass
 
-Stained Glass is a planned Tauri v2 desktop app for wrapping an interactive Claude session in a split-pane native GUI: live terminal on the left, rendered markdown preview on the right.
+Stained Glass is a Tauri v2 desktop app for wrapping an interactive Claude session in a split-pane native GUI: live terminal on the left, rendered markdown preview on the right.
 
-This repository is currently at the scaffold stage. The Rust backend and frontend shell exist so future issue-tracked work can add rmux session lifecycle, PTY streaming, pane snapshots, IPC commands, and the `stain` CLI in focused PRs.
+The MVP now has a Rust/Tauri backend scaffold, rmux session lifecycle helpers, PTY/event wiring, pane snapshot extraction, a static split-pane frontend, and the `stain` CLI workspace crate for shell-level session control.
 
 ## Repository layout
 
 ```text
 stained-glass/
 ├── Cargo.toml                  # Cargo workspace root
-├── package.json                # npm scripts for scaffold checks and Tauri commands
+├── package.json                # npm scripts for scaffold and CLI shape checks
 ├── scripts/
-│   └── check-scaffold.mjs      # verifies the expected scaffold files/config
+│   ├── check-scaffold.mjs      # verifies frontend/Tauri scaffold files/config
+│   └── check-stain-cli.mjs     # verifies the CLI crate shape without Cargo
+├── stain/                      # CLI companion binary crate
+│   ├── Cargo.toml
+│   └── src/main.rs             # `stain` open/attach/list/kill/snap
 ├── src-tauri/
 │   ├── Cargo.toml              # Tauri app crate
 │   ├── tauri.conf.json         # Tauri v2 configuration
 │   ├── build.rs
 │   └── src/
-│       └── main.rs             # minimal Tauri entrypoint
+│       ├── main.rs
+│       ├── session.rs
+│       ├── pty.rs
+│       ├── snapshot.rs
+│       └── ipc.rs
 └── src/                        # framework-free static frontend shell
     ├── index.html
     ├── style.css
     ├── ipc.js
     ├── terminal.js
-    └── preview.js
+    ├── preview.js
+    └── vendor/                 # static MVP adapters for terminal/markdown/highlight APIs
 ```
-
-The eventual `stain/` CLI crate is intentionally not added yet; it is tracked separately in #11.
 
 ## Prerequisites
 
@@ -34,38 +41,71 @@ Install these before running the Tauri app locally:
 
 - Rust toolchain with Cargo. Dependency validation in #4 found Rust `1.88+` is the safer effective baseline for current Tauri v2 transitive dependencies.
 - Node.js `18+` (this environment verified Node `20.19.2`).
+- `rmux` on `PATH` for session lifecycle, attach, list, kill, and snapshot commands.
+- `claude` on `PATH` for the default session command.
 - Tauri system dependencies for your OS:
   - Linux: WebKitGTK and related packages from the [Tauri Linux prerequisites](https://tauri.app/start/prerequisites/#linux).
   - macOS: Xcode Command Line Tools.
-- Later runtime work will also require `rmux` and `claude` on `PATH`; those are not needed for this scaffold check.
 
 ## Local verification
 
-The scaffold can be checked without a Rust toolchain:
+The lightweight checks can run without a Rust toolchain:
 
 ```bash
 npm run check:scaffold
+npm run check:stain
 ```
 
-Expected result:
+Expected results:
 
 ```text
-Scaffold check passed (11 files verified).
+Scaffold check passed (14 files verified).
+Stain CLI check passed (workspace, manifest, commands, and GUI launch notes verified).
 ```
 
-With Rust, Cargo, and Tauri prerequisites installed, the basic Tauri commands are:
+With Rust, Cargo, and Tauri prerequisites installed, run:
 
 ```bash
 npm install
 npm run tauri:dev
 npm run tauri:build
+cargo test --workspace
+cargo build --release -p stain
 ```
 
-Equivalent Cargo commands, if `cargo-tauri` is installed directly instead of using the npm CLI, are:
+Equivalent Cargo/Tauri commands, if `cargo-tauri` is installed directly instead of using the npm CLI, are:
 
 ```bash
 cargo tauri dev
 cargo tauri build
 ```
 
-The current frontend shell will render the split-pane layout. Backend IPC commands such as `start_session`, `send_input`, `resize_pty`, and `kill_session` are intentionally left for the follow-up IPC/backend issues.
+## `stain` CLI
+
+`stain` controls Stained Glass rmux sessions independently of whether the GUI is open:
+
+```bash
+stain --help
+stain open --session claude --cmd claude --cwd "$PWD"
+stain open --session claude --no-gui
+stain attach --session claude
+stain list
+stain snap --session claude
+stain kill --session claude
+```
+
+Command behavior:
+
+- `open`: creates the named rmux session when missing, using `--cmd` and `--cwd`, then attempts to launch the GUI unless `--no-gui` is set.
+- `attach`: attaches the current terminal directly to `rmux attach-session -t <session>`.
+- `list`: prints active rmux session names.
+- `snap`: prints an ANSI-stripped plain-text `rmux capture-pane` snapshot.
+- `kill`: stops the named rmux session.
+
+GUI launch behavior is platform-specific:
+
+- macOS: `stain open` uses `open -a "Stained Glass"`.
+- Linux: `stain open` first tries `gtk-launch stained-glass`, then falls back to `xdg-open stained-glass://open`.
+- Any platform: set `STAINED_GLASS_APP=/path/to/launcher` to override automatic GUI launch, or use `--no-gui` to only ensure the rmux session exists.
+
+CLI failures print actionable errors to stderr and return a non-zero exit code.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "check:scaffold": "node scripts/check-scaffold.mjs",
+    "check:stain": "node scripts/check-stain-cli.mjs",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build"
   },

--- a/scripts/check-stain-cli.mjs
+++ b/scripts/check-stain-cli.mjs
@@ -1,0 +1,52 @@
+import { access, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const root = new URL('..', import.meta.url).pathname;
+const requiredFiles = [
+  'Cargo.toml',
+  'stain/Cargo.toml',
+  'stain/src/main.rs'
+];
+
+for (const file of requiredFiles) {
+  await access(join(root, file));
+}
+
+const workspace = await readFile(join(root, 'Cargo.toml'), 'utf8');
+for (const expected of ['members = ["src-tauri", "stain"]', 'resolver = "2"']) {
+  if (!workspace.includes(expected)) {
+    throw new Error(`Cargo workspace is missing ${expected}`);
+  }
+}
+
+const manifest = await readFile(join(root, 'stain/Cargo.toml'), 'utf8');
+for (const expected of ['name = "stain"', 'clap = { version = "4", features = ["derive"] }', 'anyhow = "1"']) {
+  if (!manifest.includes(expected)) {
+    throw new Error(`stain/Cargo.toml is missing ${expected}`);
+  }
+}
+
+const main = await readFile(join(root, 'stain/src/main.rs'), 'utf8');
+for (const expected of [
+  'enum Commands',
+  'Open(OpenArgs)',
+  'Attach(SessionArgs)',
+  'List',
+  'Kill(SessionArgs)',
+  'Snap(SessionArgs)',
+  'capture-pane',
+  'list-sessions',
+  'kill-session',
+  'attach-session',
+  'new-session',
+  'std::process::exit(1)',
+  'STAINED_GLASS_APP',
+  'target_os = "macos"',
+  'target_os = "linux"'
+]) {
+  if (!main.includes(expected)) {
+    throw new Error(`stain/src/main.rs is missing ${expected}`);
+  }
+}
+
+console.log('Stain CLI check passed (workspace, manifest, commands, and GUI launch notes verified).');

--- a/stain/Cargo.toml
+++ b/stain/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "stain"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }

--- a/stain/src/main.rs
+++ b/stain/src/main.rs
@@ -1,0 +1,333 @@
+use anyhow::{bail, Context, Result};
+use clap::{Args, Parser, Subcommand};
+use std::env;
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+
+const DEFAULT_SESSION: &str = "claude";
+const DEFAULT_COMMAND: &str = "claude";
+const RMUX_BIN: &str = "rmux";
+
+#[derive(Debug, Parser)]
+#[command(name = "stain")]
+#[command(about = "Control Stained Glass rmux sessions and pane snapshots")]
+#[command(version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Create or reuse a session, then launch the Stained Glass GUI when possible.
+    Open(OpenArgs),
+    /// Attach the current terminal directly to an existing rmux session.
+    Attach(SessionArgs),
+    /// List active rmux sessions.
+    List,
+    /// Kill a named rmux session.
+    Kill(SessionArgs),
+    /// Print a plain-text snapshot of the current pane.
+    Snap(SessionArgs),
+}
+
+#[derive(Debug, Args)]
+struct SessionArgs {
+    /// rmux session name.
+    #[arg(long, default_value = DEFAULT_SESSION)]
+    session: String,
+}
+
+#[derive(Debug, Args)]
+struct OpenArgs {
+    /// rmux session name.
+    #[arg(long, default_value = DEFAULT_SESSION)]
+    session: String,
+    /// Command to start inside a newly-created session.
+    #[arg(long, default_value = DEFAULT_COMMAND)]
+    cmd: String,
+    /// Working directory for newly-created sessions.
+    #[arg(long)]
+    cwd: Option<PathBuf>,
+    /// Ensure the rmux session only; do not launch the GUI.
+    #[arg(long)]
+    no_gui: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CommandSpec {
+    program: String,
+    args: Vec<String>,
+}
+
+impl CommandSpec {
+    fn new(program: impl Into<String>, args: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            program: program.into(),
+            args: args.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(&self.program);
+        command.args(&self.args);
+        command
+    }
+
+    fn display(&self) -> String {
+        std::iter::once(self.program.as_str())
+            .chain(self.args.iter().map(String::as_str))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+fn main() {
+    if let Err(error) = run(Cli::parse()) {
+        eprintln!("stain: {error:#}");
+        std::process::exit(1);
+    }
+}
+
+fn run(cli: Cli) -> Result<()> {
+    match cli.command {
+        Commands::Open(args) => open(args),
+        Commands::Attach(args) => attach(&args.session),
+        Commands::List => list(),
+        Commands::Kill(args) => kill(&args.session),
+        Commands::Snap(args) => snap(&args.session),
+    }
+}
+
+fn open(args: OpenArgs) -> Result<()> {
+    let cwd = args
+        .cwd
+        .unwrap_or(env::current_dir().context("could not resolve current working directory")?);
+    ensure_session(&args.session, &args.cmd, &cwd)?;
+
+    if args.no_gui {
+        println!("session `{}` is ready", args.session);
+        return Ok(());
+    }
+
+    launch_gui().context("session is ready, but the Stained Glass GUI could not be launched")
+}
+
+fn attach(session: &str) -> Result<()> {
+    let spec = attach_command(session);
+    let status = spec
+        .command()
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .with_context(|| format_missing_binary(&spec))?;
+
+    if !status.success() {
+        bail!("`{}` exited with status {}", spec.display(), status);
+    }
+    Ok(())
+}
+
+fn list() -> Result<()> {
+    let spec = list_command();
+    let output = run_output(&spec)?;
+    if !output.status.success() {
+        bail!("{}", format_command_failure(&spec, &output));
+    }
+    print!("{}", String::from_utf8_lossy(&output.stdout));
+    Ok(())
+}
+
+fn kill(session: &str) -> Result<()> {
+    let spec = kill_command(session);
+    let output = run_output(&spec)?;
+    if !output.status.success() {
+        bail!("{}", format_command_failure(&spec, &output));
+    }
+    Ok(())
+}
+
+fn snap(session: &str) -> Result<()> {
+    let spec = snap_command(session);
+    let output = run_output(&spec)?;
+    if !output.status.success() {
+        bail!("{}", format_command_failure(&spec, &output));
+    }
+    print!("{}", strip_ansi(&String::from_utf8_lossy(&output.stdout)));
+    Ok(())
+}
+
+fn ensure_session(session: &str, cmd: &str, cwd: &PathBuf) -> Result<()> {
+    let has = has_session_command(session);
+    let output = run_output(&has)?;
+    if output.status.success() {
+        return Ok(());
+    }
+    if !is_missing_session_output(&output) {
+        bail!("{}", format_command_failure(&has, &output));
+    }
+
+    let create = create_command(session, cmd, cwd);
+    let output = run_output(&create)?;
+    if !output.status.success() {
+        bail!("{}", format_command_failure(&create, &output));
+    }
+    Ok(())
+}
+
+fn launch_gui() -> Result<()> {
+    if let Ok(command) = env::var("STAINED_GLASS_APP") {
+        return spawn_gui(CommandSpec::new(command, [] as [&str; 0]));
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        return spawn_gui(CommandSpec::new("open", ["-a", "Stained Glass"]));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        return spawn_gui(CommandSpec::new("gtk-launch", ["stained-glass"])).or_else(|_| {
+            spawn_gui(CommandSpec::new("xdg-open", ["stained-glass://open"] as [&str; 1]))
+        });
+    }
+
+    #[allow(unreachable_code)]
+    bail!("automatic GUI launch is not configured for this platform; run `stain attach` or launch Stained Glass manually")
+}
+
+fn spawn_gui(spec: CommandSpec) -> Result<()> {
+    spec.command()
+        .spawn()
+        .with_context(|| format!("failed to launch `{}`", spec.display()))?;
+    Ok(())
+}
+
+fn has_session_command(session: &str) -> CommandSpec {
+    CommandSpec::new(RMUX_BIN, ["has-session", "-t", session])
+}
+
+fn create_command(session: &str, cmd: &str, cwd: &PathBuf) -> CommandSpec {
+    CommandSpec::new(
+        RMUX_BIN,
+        [
+            "new-session".to_string(),
+            "-d".to_string(),
+            "-s".to_string(),
+            session.to_string(),
+            "-c".to_string(),
+            cwd.display().to_string(),
+            cmd.to_string(),
+        ],
+    )
+}
+
+fn attach_command(session: &str) -> CommandSpec {
+    CommandSpec::new(RMUX_BIN, ["attach-session", "-t", session])
+}
+
+fn list_command() -> CommandSpec {
+    CommandSpec::new(RMUX_BIN, ["list-sessions", "-F", "#{session_name}"])
+}
+
+fn kill_command(session: &str) -> CommandSpec {
+    CommandSpec::new(RMUX_BIN, ["kill-session", "-t", session])
+}
+
+fn snap_command(session: &str) -> CommandSpec {
+    CommandSpec::new(RMUX_BIN, ["capture-pane", "-p", "-e", "-t", session])
+}
+
+fn run_output(spec: &CommandSpec) -> Result<Output> {
+    spec.command()
+        .output()
+        .with_context(|| format_missing_binary(spec))
+}
+
+fn format_missing_binary(spec: &CommandSpec) -> String {
+    format!(
+        "failed to execute `{}`; is `{}` installed and in PATH?",
+        spec.display(), spec.program
+    )
+}
+
+fn is_missing_session_output(output: &Output) -> bool {
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+    .to_ascii_lowercase();
+
+    combined.contains("can't find session")
+        || combined.contains("cannot find session")
+        || combined.contains("session not found")
+        || combined.contains("no server running")
+}
+
+fn format_command_failure(spec: &CommandSpec, output: &Output) -> String {
+    let code = output
+        .status
+        .code()
+        .map_or_else(|| "terminated by signal".to_string(), |code| code.to_string());
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (true, true) => format!("`{}` failed with exit status {}", spec.display(), code),
+        (false, true) => format!("`{}` failed with exit status {}: {}", spec.display(), code, stdout),
+        (true, false) => format!("`{}` failed with exit status {}: {}", spec.display(), code, stderr),
+        (false, false) => format!(
+            "`{}` failed with exit status {}: stdout: {}; stderr: {}",
+            spec.display(), code, stdout, stderr
+        ),
+    }
+}
+
+fn strip_ansi(text: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' && chars.peek() == Some(&'[') {
+            chars.next();
+            for next in chars.by_ref() {
+                if ('@'..='~').contains(&next) {
+                    break;
+                }
+            }
+            continue;
+        }
+        output.push(ch);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constructs_open_create_command() {
+        assert_eq!(
+            create_command("demo", "claude", &PathBuf::from("/tmp/demo")),
+            CommandSpec::new(
+                "rmux",
+                ["new-session", "-d", "-s", "demo", "-c", "/tmp/demo", "claude"]
+            )
+        );
+    }
+
+    #[test]
+    fn constructs_attach_list_kill_and_snap_commands() {
+        assert_eq!(attach_command("demo"), CommandSpec::new("rmux", ["attach-session", "-t", "demo"]));
+        assert_eq!(list_command(), CommandSpec::new("rmux", ["list-sessions", "-F", "#{session_name}"]));
+        assert_eq!(kill_command("demo"), CommandSpec::new("rmux", ["kill-session", "-t", "demo"]));
+        assert_eq!(snap_command("demo"), CommandSpec::new("rmux", ["capture-pane", "-p", "-e", "-t", "demo"]));
+    }
+
+    #[test]
+    fn strips_ansi_from_snapshots() {
+        assert_eq!(strip_ansi("\u{1b}[31m# Red\u{1b}[0m\n"), "# Red\n");
+    }
+}


### PR DESCRIPTION
## Summary
- adds the `stain` workspace crate with `open`, `attach`, `list`, `kill`, and `snap` subcommands
- shells out to rmux for session lifecycle, attachment, listing, killing, and ANSI-stripped pane snapshots
- returns actionable stderr errors and non-zero exits through the CLI entrypoint
- documents macOS/Linux GUI launch behavior plus `STAINED_GLASS_APP` and `--no-gui` overrides
- adds a lightweight CLI shape check for environments without Cargo

## Verification
- [x] `node --check scripts/check-stain-cli.mjs`
- [x] `node --check scripts/check-scaffold.mjs`
- [x] `node --check src/ipc.js`
- [x] `node --check src/terminal.js`
- [x] `node --check src/preview.js`
- [x] `node --check src/vendor/xterm.js`
- [x] `node --check src/vendor/marked.js`
- [x] `node --check src/vendor/highlight.js`
- [x] Python TOML/JSON parse for Cargo manifests and Tauri config
- [x] `npm run check:scaffold`
- [x] `npm run check:stain`
- [x] `/opt/data/bin/tirith scan .`

## Not run
- `cargo test --workspace` / `cargo build --release -p stain`: this runner still lacks `cargo`/`rustc`.
- Live `rmux` smoke: this runner still lacks `rmux`.

Closes #11