### PR TITLE
Document development, verification, and packaging workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Stained Glass is a Tauri v2 desktop app for wrapping an interactive Claude session in a split-pane native GUI: live terminal on the left, rendered markdown preview on the right.
 
-The MVP now has a Rust/Tauri backend scaffold, rmux session lifecycle helpers, PTY/event wiring, pane snapshot extraction, a static split-pane frontend, and the `stain` CLI workspace crate for shell-level session control.
+The MVP contains a Rust/Tauri backend scaffold, rmux session lifecycle helpers, PTY/event wiring, pane snapshot extraction, a static split-pane frontend, and the `stain` CLI workspace crate for shell-level session control.
 
 ## Repository layout
 
@@ -35,42 +35,70 @@ stained-glass/
     └── vendor/                 # static MVP adapters for terminal/markdown/highlight APIs
 ```
 
-## Prerequisites
+## Required tools
 
-Install these before running the Tauri app locally:
+Install these before running the full app locally:
 
 - Rust toolchain with Cargo. Dependency validation in #4 found Rust `1.88+` is the safer effective baseline for current Tauri v2 transitive dependencies.
-- Node.js `18+` (this environment verified Node `20.19.2`).
+- Node.js `18+` and npm.
 - `rmux` on `PATH` for session lifecycle, attach, list, kill, and snapshot commands.
 - `claude` on `PATH` for the default session command.
 - Tauri system dependencies for your OS:
   - Linux: WebKitGTK and related packages from the [Tauri Linux prerequisites](https://tauri.app/start/prerequisites/#linux).
   - macOS: Xcode Command Line Tools.
 
-## Local verification
+Useful prerequisite probes:
 
-The lightweight checks can run without a Rust toolchain:
+```bash
+node --version
+npm --version
+rustc --version
+cargo --version
+command -v rmux
+command -v claude
+```
+
+## Setup
+
+```bash
+git clone https://github.com/zpyoung/stained-glass.git
+cd stained-glass
+npm install
+```
+
+If you only need the lightweight static checks, `npm install` is not currently required because the check scripts use Node's standard library.
+
+## Development commands
+
+Lightweight checks that do not require Rust, Cargo, Tauri system dependencies, `rmux`, or `claude`:
 
 ```bash
 npm run check:scaffold
 npm run check:stain
+node --check scripts/check-scaffold.mjs
+node --check scripts/check-stain-cli.mjs
+node --check src/ipc.js
+node --check src/terminal.js
+node --check src/preview.js
+node --check src/vendor/xterm.js
+node --check src/vendor/marked.js
+node --check src/vendor/highlight.js
+python3 -m json.tool src-tauri/tauri.conf.json >/dev/null
 ```
 
-Expected results:
-
-```text
-Scaffold check passed (14 files verified).
-Stain CLI check passed (workspace, manifest, commands, and GUI launch notes verified).
-```
-
-With Rust, Cargo, and Tauri prerequisites installed, run:
+With Rust/Cargo available:
 
 ```bash
-npm install
+cargo test --workspace
+cargo build --workspace
+cargo build --release -p stain
+```
+
+With Tauri prerequisites available:
+
+```bash
 npm run tauri:dev
 npm run tauri:build
-cargo test --workspace
-cargo build --release -p stain
 ```
 
 Equivalent Cargo/Tauri commands, if `cargo-tauri` is installed directly instead of using the npm CLI, are:
@@ -78,6 +106,105 @@ Equivalent Cargo/Tauri commands, if `cargo-tauri` is installed directly instead 
 ```bash
 cargo tauri dev
 cargo tauri build
+```
+
+## Smoke tests
+
+Run these after building in an environment with `rmux` and `claude` installed.
+
+CLI session smoke:
+
+```bash
+cargo build --release -p stain
+./target/release/stain --help
+./target/release/stain open --session stained-glass-smoke --cmd claude --cwd "$PWD" --no-gui
+./target/release/stain list
+./target/release/stain snap --session stained-glass-smoke
+./target/release/stain kill --session stained-glass-smoke
+```
+
+Expected results:
+
+- `stain --help` lists `open`, `attach`, `list`, `kill`, and `snap`.
+- `open --no-gui` creates or reuses the rmux session and exits `0`.
+- `list` includes the smoke session while it is alive.
+- `snap` prints a plain-text pane snapshot and does not include ANSI escape codes.
+- `kill` exits `0`, and the session disappears from `list`.
+
+GUI smoke:
+
+```bash
+npm run tauri:dev
+```
+
+Then verify:
+
+- The app opens at or above the configured `800x500` minimum window size.
+- The terminal pane renders raw `pty-data` on the left.
+- Typing in the terminal sends input through `send_input`.
+- The preview pane updates from `pane-snapshot` events.
+- Preview HTML is rendered from escaped markdown, not raw untrusted HTML.
+- Toolbar controls for split/preview/auto-scroll/theme remain usable at minimum size.
+
+If automatic GUI launch from `stain open` is being tested:
+
+```bash
+STAINED_GLASS_APP=/path/to/stained-glass ./target/release/stain open --session stained-glass-smoke
+```
+
+Platform defaults:
+
+- macOS: `stain open` uses `open -a "Stained Glass"`.
+- Linux: `stain open` first tries `gtk-launch stained-glass`, then falls back to `xdg-open stained-glass://open`.
+- Any platform: `STAINED_GLASS_APP=/path/to/launcher` overrides automatic GUI launch; `--no-gui` only ensures the rmux session exists.
+
+## Data flow
+
+Keystrokes:
+
+```text
+user keystroke
+  → src/terminal.js Terminal.onData()
+  → src/ipc.js sendInput(data)
+  → Tauri invoke('send_input')
+  → src-tauri/src/ipc.rs send_input()
+  → PTY input channel
+  → rmux attach-session PTY stdin
+  → claude
+```
+
+Terminal output:
+
+```text
+claude output
+  → rmux session PTY stdout
+  → src-tauri/src/pty.rs read loop
+  → Tauri emit('pty-data')
+  → src/ipc.js onPtyData()
+  → src/terminal.js Terminal.write()
+  → terminal pane
+```
+
+Preview snapshots:
+
+```text
+rmux pane buffer
+  → rmux capture-pane -p -e -t <session>
+  → src-tauri/src/snapshot.rs strip ANSI
+  → markdown-oriented extraction
+  → Tauri emit('pane-snapshot')
+  → src/ipc.js onPaneSnapshot()
+  → src/preview.js marked/highlight-compatible render
+  → preview pane
+```
+
+CLI control:
+
+```text
+stain open/list/kill/snap/attach
+  → std::process::Command argv arrays
+  → rmux CLI
+  → session lifecycle or plain-text snapshot output
 ```
 
 ## `stain` CLI
@@ -102,10 +229,60 @@ Command behavior:
 - `snap`: prints an ANSI-stripped plain-text `rmux capture-pane` snapshot.
 - `kill`: stops the named rmux session.
 
-GUI launch behavior is platform-specific:
-
-- macOS: `stain open` uses `open -a "Stained Glass"`.
-- Linux: `stain open` first tries `gtk-launch stained-glass`, then falls back to `xdg-open stained-glass://open`.
-- Any platform: set `STAINED_GLASS_APP=/path/to/launcher` to override automatic GUI launch, or use `--no-gui` to only ensure the rmux session exists.
-
 CLI failures print actionable errors to stderr and return a non-zero exit code.
+
+## Packaging commands
+
+Build local artifacts:
+
+```bash
+npm run tauri:build
+cargo build --release -p stain
+```
+
+Expected local outputs depend on platform and Tauri configuration. Common paths include:
+
+- Tauri app bundles/installers under `src-tauri/target/release/bundle/`
+- `stain` binary at `target/release/stain`
+
+Do not treat a local package build as a release. Signing, notarization, uploading packages, creating GitHub releases, publishing installers, or changing production distribution settings require Zach's explicit approval.
+
+## PR verification checklist
+
+For any PR, include the exact commands you ran and call out missing local prerequisites clearly.
+
+Backend / Rust changes:
+
+- [ ] `cargo test --workspace`
+- [ ] `cargo build --workspace`
+- [ ] Relevant unit tests cover command construction or state transitions.
+- [ ] If `rmux` behavior changed, run or document a live `rmux` smoke test.
+
+Frontend changes:
+
+- [ ] `npm run check:scaffold`
+- [ ] `node --check src/ipc.js`
+- [ ] `node --check src/terminal.js`
+- [ ] `node --check src/preview.js`
+- [ ] Browser/Tauri smoke for terminal rendering, input, preview updates, and minimum-size usability when a GUI environment is available.
+
+CLI changes:
+
+- [ ] `npm run check:stain`
+- [ ] `cargo test -p stain`
+- [ ] `cargo build --release -p stain`
+- [ ] `stain --help` lists all MVP commands.
+- [ ] `stain snap --session <name>` returns plain text in a live rmux environment.
+- [ ] Failure paths return non-zero exit codes with actionable stderr.
+
+Packaging changes:
+
+- [ ] `npm run tauri:build`
+- [ ] `cargo build --release -p stain`
+- [ ] Artifact paths are documented.
+- [ ] Release/signing/publishing steps are not performed without Zach's explicit approval.
+
+Security / quality:
+
+- [ ] No secrets, local credentials, profile paths, or machine-specific maintainer notes are committed.
+- [ ] Run the repository security scanner if available, e.g. `/opt/data/bin/tirith scan .`.


### PR DESCRIPTION
## Summary
- expands README setup, prerequisite, development, and smoke-test instructions
- documents keystroke/PTY/snapshot/CLI data flows
- adds packaging commands while explicitly keeping release/signing/publishing approval-gated
- adds PR verification checklists for backend, frontend, CLI, packaging, and security

## Verification
- [x] `node --check scripts/check-scaffold.mjs`
- [x] `node --check scripts/check-stain-cli.mjs`
- [x] `npm run check:scaffold`
- [x] `npm run check:stain`
- [x] Python TOML/JSON parse plus README content assertions
- [x] `/opt/data/bin/tirith scan .`

## Not run
- Rust/Cargo/Tauri/rmux smoke commands are documented but not run here because this runner still lacks `cargo`, `rustc`, and `rmux`.

Closes #12