### PR TITLE
Validate toolchain with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,137 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  static-checks:
+    name: Static checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run lightweight scaffold checks
+        run: |
+          npm run check:scaffold
+          npm run check:stain
+          node --check scripts/check-scaffold.mjs
+          node --check scripts/check-stain-cli.mjs
+          node --check src/ipc.js
+          node --check src/terminal.js
+          node --check src/preview.js
+          node --check src/vendor/xterm.js
+          node --check src/vendor/marked.js
+          node --check src/vendor/highlight.js
+          python3 -m json.tool src-tauri/tauri.conf.json >/dev/null
+
+  rust-tauri:
+    name: Rust, Tauri, and CLI build
+    runs-on: ubuntu-latest
+    container: ubuntu:24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Linux Tauri prerequisites
+        run: |
+          apt-get update
+          apt-get install -y \
+            build-essential \
+            curl \
+            file \
+            git \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            patchelf \
+            pkg-config
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry and build output
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install npm dependencies
+        run: npm install
+
+      - name: Run Rust tests
+        run: cargo test --workspace
+
+      - name: Build Rust workspace
+        run: cargo build --workspace
+
+      - name: Build stain release binary
+        run: cargo build --release -p stain
+
+      - name: Build Tauri bundle
+        run: npm run tauri:build
+
+  rmux-smoke:
+    name: rmux CLI smoke
+    runs-on: ubuntu-latest
+    needs: rust-tauri
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry and build output
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install rmux
+        run: cargo install rmux --locked
+
+      - name: Build stain release binary
+        run: cargo build --release -p stain
+
+      - name: Exercise stain against rmux without Claude credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./target/release/stain --help
+          ./target/release/stain open \
+            --session stained-glass-ci \
+            --cmd "sh -lc 'printf \"# CI smoke\\n\\n- rmux session is alive\\n\"; sleep 30'" \
+            --cwd "$PWD" \
+            --no-gui
+          ./target/release/stain list | grep stained-glass-ci
+          ./target/release/stain snap --session stained-glass-ci | tee /tmp/stain-snap.txt
+          grep '# CI smoke' /tmp/stain-snap.txt
+          ./target/release/stain kill --session stained-glass-ci
+
+  ci-summary:
+    name: CI summary
+    runs-on: ubuntu-latest
+    needs:
+      - static-checks
+      - rust-tauri
+      - rmux-smoke
+    if: always()
+    steps:
+      - name: Check required jobs
+        run: |
+          test "${{ needs.static-checks.result }}" = "success"
+          test "${{ needs.rust-tauri.result }}" = "success"
+          test "${{ needs.rmux-smoke.result }}" = "success"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ node --check src/vendor/highlight.js
 python3 -m json.tool src-tauri/tauri.conf.json >/dev/null
 ```
 
+GitHub Actions runs these checks on pushes and pull requests, then validates the Rust/Tauri toolchain on Ubuntu by installing the Tauri Linux prerequisites, running workspace tests/builds, building the Tauri bundle, installing `rmux`, and smoke-testing `stain` against a temporary rmux session. The CI smoke uses a shell command instead of real `claude` credentials; live Claude GUI validation still needs a developer machine with `claude` authenticated.
+
 With Rust/Cargo available:
 
 ```bash


### PR DESCRIPTION
## Summary
- adds a CI workflow for PRs, main pushes, and manual dispatch
- runs static Node/config checks
- validates Rust/Tauri on Ubuntu with Linux Tauri prerequisites, workspace tests/builds, `stain` release build, and `npm run tauri:build`
- installs `rmux` in CI and smoke-tests `stain` with a temporary non-Claude rmux session
- documents that CI substitutes a shell command for `claude`; live authenticated Claude GUI validation remains manual

## Verification
- [x] Python content assertions for workflow/README and TOML/JSON parsing
- [x] `node --check scripts/check-scaffold.mjs`
- [x] `node --check scripts/check-stain-cli.mjs`
- [x] `npm run check:scaffold`
- [x] `npm run check:stain`
- [x] `/opt/data/bin/tirith scan .`

Refs #23